### PR TITLE
Tenary -> Ternary

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -999,27 +999,27 @@ void codegen_generate_exp_parenthesis_node(struct node *node, struct history *hi
     codegen_generate_expressionable(node->parenthesis.exp, history_down(history, codegen_remove_uninheritable_flags(history->flags)));
 }
 
-void codegen_generate_tenary(struct node *node, struct history *history)
+void codegen_generate_ternary(struct node *node, struct history *history)
 {
     int true_label_id = codegen_label_count();
     int false_label_id = codegen_label_count();
-    int tenary_end_label_id = codegen_label_count();
+    int ternary_end_label_id = codegen_label_count();
 
     struct datatype last_dtype;
     assert(asm_datatype_back(&last_dtype));
     asm_push_ins_pop("eax", STACK_FRAME_ELEMENT_TYPE_PUSHED_VALUE, "result_value");
     asm_push("cmp eax, 0");
-    asm_push("je .tenary_false_%i", false_label_id);
-    asm_push(".tenary_true_%i:", true_label_id);
+    asm_push("je .ternary_false_%i", false_label_id);
+    asm_push(".ternary_true_%i:", true_label_id);
 
-    codegen_generate_expressionable(node->tenary.true_node, history_down(history, 0));
+    codegen_generate_expressionable(node->ternary.true_node, history_down(history, 0));
     asm_push_ins_pop_or_ignore("eax", STACK_FRAME_ELEMENT_TYPE_PUSHED_VALUE, "result_value");
-    asm_push("jmp .tenary_end_%i", tenary_end_label_id);
+    asm_push("jmp .ternary_end_%i", ternary_end_label_id);
 
-    asm_push(".tenary_false_%i:", false_label_id);
-    codegen_generate_expressionable(node->tenary.false_node, history_down(history, 0));
+    asm_push(".ternary_false_%i:", false_label_id);
+    codegen_generate_expressionable(node->ternary.false_node, history_down(history, 0));
     asm_push_ins_pop_or_ignore("eax", STACK_FRAME_ELEMENT_TYPE_PUSHED_VALUE, "result_value");
-    asm_push(".tenary_end_%i:", tenary_end_label_id);
+    asm_push(".ternary_end_%i:", ternary_end_label_id);
 }
 
 void codegen_generate_cast(struct node *node, struct history *history)
@@ -1068,7 +1068,7 @@ void codegen_generate_expressionable(struct node *node, struct history *history)
         break;
 
     case NODE_TYPE_TENARY:
-        codegen_generate_tenary(node, history);
+        codegen_generate_ternary(node, history);
         break;
 
     case NODE_TYPE_CAST:

--- a/compiler.h
+++ b/compiler.h
@@ -675,11 +675,11 @@ struct node
             struct node *val;
         } var;
 
-        struct node_tenary
+        struct node_ternary
         {
             struct node *true_node;
             struct node *false_node;
-        } tenary;
+        } ternary;
 
         struct varlist
         {
@@ -1329,7 +1329,7 @@ bool op_is_address(const char *op);
 struct node *struct_node_for_name(struct compile_process *current_process, const char *name);
 struct node *union_node_for_name(struct compile_process *current_process, const char *name);
 
-void make_tenary_node(struct node *true_node, struct node *false_node);
+void make_ternary_node(struct node *true_node, struct node *false_node);
 
 void make_default_node();
 void make_case_node(struct node *exp_node);
@@ -1535,7 +1535,7 @@ void expressionable_parse_for_indirection_unary(struct expressionable *expressio
 void expressionable_parse_for_normal_unary(struct expressionable *expressionable);
 void expressionable_parse_unary(struct expressionable *expressionable);
 void expressionable_parse_for_operator(struct expressionable *expressionable);
-void expressionable_parse_tenary(struct expressionable* expressionable);
+void expressionable_parse_ternary(struct expressionable* expressionable);
 int expressionable_parse_exp(struct expressionable *expressionable, struct token *token);
 int expressionable_parse_token(struct expressionable *expressionable, struct token *token, int flags);
 int expressionable_parse_single_with_flags(struct expressionable *expressionable, int flags);
@@ -1610,7 +1610,7 @@ struct expressionable_config
         EXPRESSIONABLE_MAKE_PARENTHESES_NODE make_parentheses_node;
         EXPRESSIONABLE_MAKE_UNARY_NODE make_unary_node;
         EXPRESSIONABLE_MAKE_UNARY_INDIRECTION_NODE make_unary_indirection_node;
-        EXPRESSIONABLE_MAKE_TENARY_NODE make_tenary_node;
+        EXPRESSIONABLE_MAKE_TENARY_NODE make_ternary_node;
         EXPRESSIONABLE_GET_NODE_TYPE get_node_type;
         EXPRESSIONABLE_GET_LEFT_NODE get_left_node;
         EXPRESSIONABLE_GET_RIGHT_NODE get_right_node;

--- a/expressionable.c
+++ b/expressionable.c
@@ -378,12 +378,12 @@ void expressionable_parse_for_operator(struct expressionable *expressionable)
     expressionable_node_push(expressionable, exp_node);
 }
 
-void expressionable_parse_tenary(struct expressionable* expressionable)
+void expressionable_parse_ternary(struct expressionable* expressionable)
 {
     void* condition_operand = expressionable_node_pop(expressionable);
     expressionable_expect_op(expressionable, "?");
 
-    // Parse the TRUE part of the tenary
+    // Parse the TRUE part of the ternary
     expressionable_parse(expressionable);
     void* true_result_node = expressionable_node_pop(expressionable);
     expressionable_expect_sym(expressionable, ':');
@@ -392,10 +392,10 @@ void expressionable_parse_tenary(struct expressionable* expressionable)
     expressionable_parse(expressionable);
     void* false_result_node = expressionable_node_pop(expressionable);
 
-    expressionable_callbacks(expressionable)->make_tenary_node(expressionable, true_result_node, false_result_node);
+    expressionable_callbacks(expressionable)->make_ternary_node(expressionable, true_result_node, false_result_node);
 
-    void* tenary_node = expressionable_node_pop(expressionable);
-    expressionable_callbacks(expressionable)->make_expression_node(expressionable, condition_operand, tenary_node, "?");
+    void* ternary_node = expressionable_node_pop(expressionable);
+    expressionable_callbacks(expressionable)->make_expression_node(expressionable, condition_operand, ternary_node, "?");
 }
 
 int expressionable_parse_exp(struct expressionable *expressionable, struct token *token)
@@ -406,7 +406,7 @@ int expressionable_parse_exp(struct expressionable *expressionable, struct token
     }
     else if(S_EQ(expressionable_peek_next(expressionable)->sval, "?"))
     {
-        expressionable_parse_tenary(expressionable);
+        expressionable_parse_ternary(expressionable);
     }
     else
     {

--- a/node.c
+++ b/node.c
@@ -64,9 +64,9 @@ void make_cast_node(struct datatype *dtype, struct node *operand_node)
     node_create(&(struct node){.type = NODE_TYPE_CAST, .cast.dtype = *dtype, .cast.operand = operand_node});
 }
 
-void make_tenary_node(struct node *true_node, struct node *false_node)
+void make_ternary_node(struct node *true_node, struct node *false_node)
 {
-    node_create(&(struct node){.type = NODE_TYPE_TENARY, .tenary.true_node = true_node, .tenary.false_node = false_node});
+    node_create(&(struct node){.type = NODE_TYPE_TENARY, .ternary.true_node = true_node, .ternary.false_node = false_node});
 }
 
 void make_case_node(struct node *exp_node)

--- a/parser.c
+++ b/parser.c
@@ -123,7 +123,7 @@ void parse_keyword(struct history *history);
 struct vector *parse_function_arguments(struct history *history);
 void parse_expressionable_root(struct history *history);
 void parse_label(struct history *history);
-void parse_for_tenary(struct history *history);
+void parse_for_ternary(struct history *history);
 void parse_datatype(struct datatype *dtype);
 void parse_for_cast();
 
@@ -567,7 +567,7 @@ int parse_exp(struct history *history)
     }
     else if (S_EQ(token_peek_next()->sval, "?"))
     {
-        parse_for_tenary(history);
+        parse_for_ternary(history);
     }
     else if (S_EQ(token_peek_next()->sval, ","))
     {
@@ -1836,7 +1836,7 @@ void parse_label(struct history *history)
     make_label_node(label_name_node);
 }
 
-void parse_for_tenary(struct history *history)
+void parse_for_ternary(struct history *history)
 {
     struct node *condition_node = node_pop();
     expect_op("?");
@@ -1845,9 +1845,9 @@ void parse_for_tenary(struct history *history)
     expect_sym(':');
     parse_expressionable_root(history_down(history, HISTORY_FLAG_PARENTHESES_IS_NOT_A_FUNCTION_CALL));
     struct node *false_result_node = node_pop();
-    make_tenary_node(true_result_node, false_result_node);
-    struct node *tenary_node = node_pop();
-    make_exp_node(condition_node, tenary_node, "?");
+    make_ternary_node(true_result_node, false_result_node);
+    struct node *ternary_node = node_pop();
+    make_exp_node(condition_node, ternary_node, "?");
 }
 
 void parse_sizeof(struct history* history)

--- a/preprocessor/preprocessor.c
+++ b/preprocessor/preprocessor.c
@@ -85,11 +85,11 @@ struct preprocessor_node
             struct preprocessor_node *right;
         } joined;
 
-        struct preprocessor_tenary_node
+        struct preprocessor_ternary_node
         {
             struct preprocessor_node *true_node;
             struct preprocessor_node *false_node;
-        } tenary;
+        } ternary;
     };
 
     const char *sval;
@@ -340,12 +340,12 @@ void preprocessor_make_parentheses_node(struct expressionable *expressionable, v
     parentheses_node.parenthesis.exp = node_ptr;
     expressionable_node_push(expressionable, preprocessor_node_create(&parentheses_node));
 }
-void preprocessor_make_tenary_node(struct expressionable *expressionable, void *true_result_node_ptr, void *false_result_node_ptr)
+void preprocessor_make_ternary_node(struct expressionable *expressionable, void *true_result_node_ptr, void *false_result_node_ptr)
 {
     struct preprocessor_node *true_result_node = true_result_node_ptr;
     struct preprocessor_node *false_result_node = false_result_node_ptr;
 
-    expressionable_node_push(expressionable, preprocessor_node_create(&(struct preprocessor_node){.type = PREPROCESSOR_TENARY_NODE, .tenary.true_node = true_result_node, .tenary.false_node = false_result_node}));
+    expressionable_node_push(expressionable, preprocessor_node_create(&(struct preprocessor_node){.type = PREPROCESSOR_TENARY_NODE, .ternary.true_node = true_result_node, .ternary.false_node = false_result_node}));
 }
 
 int preprocessor_get_node_type(struct expressionable *expressionable, void *node)
@@ -444,7 +444,7 @@ struct expressionable_config preprocessor_expressionable_config =
         .callbacks.make_unary_node = preprocessor_make_unary_node,
         .callbacks.make_expression_node = preprocessor_make_expression_node,
         .callbacks.make_parentheses_node = preprocessor_make_parentheses_node,
-        .callbacks.make_tenary_node = preprocessor_make_tenary_node,
+        .callbacks.make_ternary_node = preprocessor_make_ternary_node,
         .callbacks.get_node_type = preprocessor_get_node_type,
         .callbacks.get_left_node = preprocessor_get_left_node,
         .callbacks.get_right_node = preprocessor_get_right_node,
@@ -1413,11 +1413,11 @@ int preprocessor_evaluate_exp(struct compile_process *compiler, struct preproces
     {
         if (left_operand)
         {
-            return preprocessor_evaluate(compiler, node->exp.right->tenary.true_node);
+            return preprocessor_evaluate(compiler, node->exp.right->ternary.true_node);
         }
         else
         {
-            return preprocessor_evaluate(compiler, node->exp.right->tenary.false_node);
+            return preprocessor_evaluate(compiler, node->exp.right->ternary.false_node);
         }
     }
 


### PR DESCRIPTION
Minor spelling fixes. I have ensured the code still compiles properly.
Wikipedia has an article on the [ternary conditional operator](https://en.wikipedia.org/wiki/Ternary_conditional_operator), which serves as my citation that "ternary" is the correct spelling.

Feel free to simply close this pull request if you don't want it, I won't take any offense.