### PR TITLE
Add logical or

### DIFF
--- a/codegen.c
+++ b/codegen.c
@@ -1749,6 +1749,10 @@ int codegen_set_flag_for_operator(const char *op)
     {
         flag |= EXPRESSION_LOGICAL_AND;
     }
+    else if (S_EQ(op, "||"))
+    {
+        flag |= EXPRESSION_LOGICAL_OR;
+    }
     else if (S_EQ(op, "<<"))
     {
         flag |= EXPRESSION_IS_BITSHIFT_LEFT;

--- a/helper.c
+++ b/helper.c
@@ -364,7 +364,7 @@ void datatype_decrement_pointer(struct datatype* dtype)
 long arithmetic(struct compile_process* compiler, long left_operand, long right_operand, const char* op, bool* success)
 {
     *success = true;
-    int result = 0;
+    long result = 0;
     if (S_EQ(op, "*"))
     {
         result = left_operand * right_operand;


### PR DESCRIPTION
Two fixes:
- match `result` to return value of function; this change does affect resulting executable
- add missing `EXPRESSION_LOGICAL_OR`; I think this change does not affect resulting executable

Feel free to simply close this pull request if you don't want it, I won't take any offense.